### PR TITLE
Migrate to AWS SDK v2.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,13 +58,16 @@ kotlinDslPluginOptions {
 }
 
 dependencies {
+    implementation(platform("io.netty:netty-bom:4.1.46.Final"))
+    implementation("io.netty:netty-buffer")
+
     implementation(platform("software.amazon.awssdk:bom:2.13.76"))
     implementation("software.amazon.awssdk:s3")
 
     testImplementation(platform("org.junit:junit-bom:5.7.0-M1"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("com.adobe.testing:s3mock-junit5:2.1.24") {
+    testImplementation("com.adobe.testing:s3mock-junit5:2.1.22") {
         // Gradle has its own logging
         exclude("ch.qos.logback", "logback-classic")
         exclude("org.apache.logging.log4j", "log4j-to-slf4j")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,12 +58,13 @@ kotlinDslPluginOptions {
 }
 
 dependencies {
-    implementation("com.amazonaws:aws-java-sdk-s3:1.11.751")
+    implementation(platform("software.amazon.awssdk:bom:2.13.76"))
+    implementation("software.amazon.awssdk:s3")
 
     testImplementation(platform("org.junit:junit-bom:5.7.0-M1"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("com.adobe.testing:s3mock-junit5:2.1.22") {
+    testImplementation("com.adobe.testing:s3mock-junit5:2.1.24") {
         // Gradle has its own logging
         exclude("ch.qos.logback", "logback-classic")
         exclude("org.apache.logging.log4j", "log4j-to-slf4j")

--- a/src/main/java/com/github/burrunan/s3cache/internal/awssdk/InputStreamResponse.java
+++ b/src/main/java/com/github/burrunan/s3cache/internal/awssdk/InputStreamResponse.java
@@ -1,0 +1,143 @@
+package com.github.burrunan.s3cache.internal.awssdk;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.SdkPublisher;
+
+public final class InputStreamResponse<T> extends InputStream
+        implements AsyncResponseTransformer<T, InputStreamResponse<T>> {
+
+    private static final ByteBuffer EOS = ByteBuffer.wrap(new byte[0]);
+    private static final Subscription CLOSED = new Subscription() {
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    };
+
+    private final CompletableFuture<InputStreamResponse<T>> future = new CompletableFuture<>();
+    private final ByteBuf buf = Unpooled.buffer();
+    private final BlockingQueue<ByteBuffer> readQueue = new LinkedBlockingDeque<>();
+    private final AtomicReference<Subscription> subscription = new AtomicReference<>();
+
+    private volatile T response;
+    private volatile Throwable readError;
+    private volatile boolean complete;
+
+    public T response() {
+        return response;
+    }
+
+    @Override
+    public CompletableFuture<InputStreamResponse<T>> prepare() {
+        return future;
+    }
+
+    @Override
+    public void onResponse(T response) {
+        this.response = response;
+        future.complete(this);
+    }
+
+    @Override
+    public void onStream(SdkPublisher<ByteBuffer> publisher) {
+        publisher.subscribe(new Subscriber<ByteBuffer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                if (subscription.compareAndSet(null, s)) {
+                    s.request(1);
+                } else {
+                    // Already closed so cancel the stream.
+                    s.cancel();
+                }
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+                if (byteBuffer.hasRemaining()) {
+                    readQueue.add(byteBuffer);
+                } else {
+                    subscription.get().request(1);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                readError = t;
+                readQueue.add(EOS);
+            }
+
+            @Override
+            public void onComplete() {
+                readQueue.add(EOS);
+            }
+        });
+    }
+
+    @Override
+    public void exceptionOccurred(Throwable error) {
+        if (response == null) {
+            future.completeExceptionally(error);
+        } else {
+            readError = error;
+            readQueue.add(EOS);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (complete) {
+            return -1;
+        }
+
+        if (buf.isReadable()) {
+            return buf.readByte() & 0xff;
+        }
+
+        final ByteBuffer buffer;
+        try {
+            buffer = readQueue.take();
+        } catch (InterruptedException e) {
+            throw new IOException("Could not read response", e);
+        }
+        if (readError != null) {
+            throw new IOException("Could not read response", readError);
+        }
+        if (buffer == EOS) {
+            complete = true;
+            return -1;
+        }
+
+        subscription.get().request(1);
+        buf.discardSomeReadBytes();
+        buf.writeBytes(buffer);
+        return buf.readByte() & 0xff;
+    }
+
+    @Override
+    public void close() {
+        if (subscription.compareAndSet(null, CLOSED)) {
+            // No subscription yet, when it comes in we'll cancel it above.
+            return;
+        }
+        Subscription subscription = this.subscription.get();
+        if (this.subscription.compareAndSet(subscription, CLOSED)) {
+            subscription.cancel();
+        }
+    }
+}

--- a/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
+++ b/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
@@ -4,23 +4,30 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.jetbrains.annotations.NotNull;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 
 public final class OutputStreamRequest extends OutputStream implements AsyncRequestBody {
 
     private final long contentLength;
-    private final CountDownLatch subscribed;
+    private final AtomicLong demand;
+    private final BlockingQueue<String> barrier;
 
     private Subscriber<? super ByteBuffer> subscriber;
 
+    private volatile boolean cancelled;
+
     public OutputStreamRequest(long contentLength) {
         this.contentLength = contentLength;
-        subscribed = new CountDownLatch(1);
+        demand = new AtomicLong();
+        barrier = new ArrayBlockingQueue<>(1);
     }
 
     @Override
@@ -31,18 +38,18 @@ public final class OutputStreamRequest extends OutputStream implements AsyncRequ
     @Override
     public void subscribe(Subscriber<? super ByteBuffer> s) {
         subscriber = s;
-        subscribed.countDown();
+        s.onSubscribe(new OutputStreamSubscription());
     }
 
     @Override
     public void write(int b) throws IOException {
-        waitForSubscriber();
+        waitForDemand();
         subscriber.onNext(ByteBuffer.wrap(new byte[] { (byte) b }));
     }
 
     @Override
     public void write(@NotNull byte[] b, int off, int len) throws IOException {
-        waitForSubscriber();
+        waitForDemand();
         subscriber.onNext(ByteBuffer.wrap(b, off, len));
     }
 
@@ -51,11 +58,30 @@ public final class OutputStreamRequest extends OutputStream implements AsyncRequ
         subscriber.onComplete();
     }
 
-    private void waitForSubscriber() throws IOException {
-        try {
-            subscribed.await();
-        } catch (InterruptedException e) {
-            throw new IOException("Interrupted while waiting for async subscriber", e);
+    private void waitForDemand() throws IOException {
+        if (cancelled) {
+            throw new IOException("Stream cancelled during write.");
+        }
+        if (demand.get() == 0) {
+            try {
+                barrier.take();
+            } catch (InterruptedException e) {
+                throw new IOException("Interrupted while waiting for async subscriber", e);
+            }
+        }
+        demand.decrementAndGet();
+    }
+
+    private class OutputStreamSubscription implements Subscription {
+        @Override
+        public void request(long n) {
+            demand.addAndGet(n);
+            barrier.offer("");
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
         }
     }
 }

--- a/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
+++ b/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
@@ -16,7 +16,7 @@ public final class OutputStreamRequest extends OutputStream implements AsyncRequ
     private final long contentLength;
     private final CountDownLatch subscribed;
 
-    private volatile Subscriber<? super ByteBuffer> subscriber;
+    private Subscriber<? super ByteBuffer> subscriber;
 
     public OutputStreamRequest(long contentLength) {
         this.contentLength = contentLength;

--- a/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
+++ b/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
@@ -11,7 +11,7 @@ import org.reactivestreams.Subscriber;
 
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 
-public class OutputStreamRequest extends OutputStream implements AsyncRequestBody {
+public final class OutputStreamRequest extends OutputStream implements AsyncRequestBody {
 
     private final long contentLength;
     private final CountDownLatch subscribed;

--- a/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
+++ b/src/main/java/com/github/burrunan/s3cache/internal/awssdk/OutputStreamRequest.java
@@ -1,0 +1,61 @@
+package com.github.burrunan.s3cache.internal.awssdk;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+
+import org.jetbrains.annotations.NotNull;
+import org.reactivestreams.Subscriber;
+
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+
+public class OutputStreamRequest extends OutputStream implements AsyncRequestBody {
+
+    private final long contentLength;
+    private final CountDownLatch subscribed;
+
+    private volatile Subscriber<? super ByteBuffer> subscriber;
+
+    public OutputStreamRequest(long contentLength) {
+        this.contentLength = contentLength;
+        subscribed = new CountDownLatch(1);
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return Optional.of(contentLength);
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        subscriber = s;
+        subscribed.countDown();
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        waitForSubscriber();
+        subscriber.onNext(ByteBuffer.wrap(new byte[] { (byte) b }));
+    }
+
+    @Override
+    public void write(@NotNull byte[] b, int off, int len) throws IOException {
+        waitForSubscriber();
+        subscriber.onNext(ByteBuffer.wrap(b, off, len));
+    }
+
+    @Override
+    public void close() {
+        subscriber.onComplete();
+    }
+
+    private void waitForSubscriber() throws IOException {
+        try {
+            subscribed.await();
+        } catch (InterruptedException e) {
+            throw new IOException("Interrupted while waiting for async subscriber", e);
+        }
+    }
+}

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
@@ -16,16 +16,17 @@
 package com.github.burrunan.s3cache.internal
 
 import com.github.burrunan.s3cache.AwsS3BuildCache
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.auth.AnonymousAWSCredentials
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.auth.BasicSessionCredentials
-import com.amazonaws.client.builder.AwsClientBuilder
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import org.gradle.caching.BuildCacheService
 import org.gradle.caching.BuildCacheServiceFactory
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder
+import java.net.URI
 
 private val logger = LoggerFactory.getLogger(AwsS3BuildCacheServiceFactory::class.java)
 
@@ -69,51 +70,46 @@ class AwsS3BuildCacheServiceFactory : BuildCacheServiceFactory<AwsS3BuildCache> 
         check(!config.bucket.isNullOrEmpty()) { "S3 build cache has no bucket configured" }
     }
 
-    private fun createS3Client(config: AwsS3BuildCache) = AmazonS3ClientBuilder.standard().run {
+    private fun createS3Client(config: AwsS3BuildCache) = S3AsyncClient.builder().run {
         addHttpHeaders(config)
         addCredentials(config)
-        if (config.endpoint.isNullOrEmpty()) {
-            withRegion(config.region)
-        } else {
-            withEndpointConfiguration(
-                AwsClientBuilder.EndpointConfiguration(
-                    config.endpoint,
-                    config.region
-                )
-            )
+        region(Region.of(config.region))
+        config.endpoint?.let {
+            val endpoint = if (it.startsWith("http")) it else "https://${it}"
+            endpointOverride(URI.create(endpoint))
         }
-        enablePathStyleAccess()
         build()
     }
 
-    private fun AmazonS3ClientBuilder.addHttpHeaders(
+    private fun S3AsyncClientBuilder.addHttpHeaders(
         config: AwsS3BuildCache
     ) {
-        clientConfiguration = ClientConfiguration().apply {
-            for ((key, value) in config.headers ?: mapOf()) {
-                if (key != null && value != null) {
-                    addHeader(key, value)
+        config.headers?.let { headers ->
+            overrideConfiguration {
+                for ((key, value) in config.headers ?: mapOf()) {
+                    if (key != null && value != null) {
+                        it.putHeader(key, value)
+                    }
                 }
             }
         }
     }
 
-    private fun AmazonS3ClientBuilder.addCredentials(config: AwsS3BuildCache) {
+    private fun S3AsyncClientBuilder.addCredentials(config: AwsS3BuildCache) {
         val credentials = when {
-            config.awsAccessKeyId.isNullOrBlank() && config.awsSecretKey.isNullOrBlank() -> when {
+            config.awsAccessKeyId.isNullOrBlank() || config.awsSecretKey.isNullOrBlank() -> when {
                 config.lookupDefaultAwsCredentials -> return
-                else -> AnonymousAWSCredentials()
+                else -> AnonymousCredentialsProvider.create()
             }
-            config.awsAccessKeyId.isNullOrEmpty() ->
-                BasicAWSCredentials(config.awsAccessKeyId, config.awsSecretKey)
-            else ->
-                BasicSessionCredentials(
-                    config.awsAccessKeyId,
-                    config.awsSecretKey,
-                    config.sessionToken
-                )
+            !config.sessionToken.isNullOrEmpty() ->
+                StaticCredentialsProvider.create(AwsSessionCredentials.create(
+                        config.awsAccessKeyId,
+                        config.awsSecretKey,
+                        config.sessionToken
+                ))
+            else -> StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(config.awsAccessKeyId, config.awsSecretKey))
         }
-
-        withCredentials(AWSStaticCredentialsProvider(credentials))
+        credentialsProvider(credentials)
     }
 }

--- a/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
+++ b/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
@@ -57,8 +57,8 @@ class RemoteCacheTest: BaseGradleTest() {
         @JvmStatic
         private fun gradleVersionAndSettings(): Iterable<Arguments> {
             if (!isCI) {
-                // Use the current Gradle version to make the test faster
-                return listOf(arguments("6.6"))
+                // Use only the minimum supported Gradle version to make the test faster
+                return listOf(arguments("4.1"))
             }
             return mutableListOf<Arguments>().apply {
                 if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {

--- a/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
+++ b/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
@@ -58,7 +58,7 @@ class RemoteCacheTest: BaseGradleTest() {
         private fun gradleVersionAndSettings(): Iterable<Arguments> {
             if (!isCI) {
                 // Use the current Gradle version to make the test faster
-                return listOf(arguments("4.1"))
+                return listOf(arguments("6.6"))
             }
             return mutableListOf<Arguments>().apply {
                 if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {


### PR DESCRIPTION
@vlsi Thanks for the work on this plugin :) I noticed it's still using AWS SDK v1 and figured it'd be good to migrate to v2. V2 is the currently developed version, and it has a netty-based client. I considered adding tcnative as well for less garbage when TLS decrypting large payloads but left that out for now, let me know if you have any thoughts on that.