### PR TITLE
Upgrade AWS SDK to 2.17 to remove jackson dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,8 +58,7 @@ kotlinDslPluginOptions {
 }
 
 dependencies {
-    implementation(platform("software.amazon.awssdk:bom:2.16.52"))
-    implementation("software.amazon.awssdk:s3") {
+    implementation("software.amazon.awssdk:s3:2.17.106") {
         // We do not use netty client so far
         exclude("software.amazon.awssdk", "netty-nio-client")
     }


### PR DESCRIPTION
https://aws.amazon.com/blogs/developer/the-aws-sdk-for-java-2-17-removes-its-external-dependency-on-jackson/