### PR TITLE
Make the plugin work with AWS SSO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,8 @@ kotlinDslPluginOptions {
 
 dependencies {
     implementation(platform("software.amazon.awssdk:bom:2.17.106"))
+    // Needed to automatically enable AWS SSO login
+    implementation("software.amazon.awssdk:sso")
     implementation("software.amazon.awssdk:s3") {
         // We do not use netty client so far
         exclude("software.amazon.awssdk", "netty-nio-client")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,8 @@ kotlinDslPluginOptions {
 }
 
 dependencies {
-    implementation("software.amazon.awssdk:s3:2.17.106") {
+    implementation(platform("software.amazon.awssdk:bom:2.17.106"))
+    implementation("software.amazon.awssdk:s3") {
         // We do not use netty client so far
         exclude("software.amazon.awssdk", "netty-nio-client")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ kotlinDslPluginOptions {
 }
 
 dependencies {
-    implementation(platform("software.amazon.awssdk:bom:2.17.106"))
+    implementation(platform("software.amazon.awssdk:bom:2.17.267"))
     // Needed to automatically enable AWS SSO login
     implementation("software.amazon.awssdk:sso")
     implementation("software.amazon.awssdk:s3") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,8 +59,9 @@ kotlinDslPluginOptions {
 
 dependencies {
     implementation(platform("software.amazon.awssdk:bom:2.17.267"))
-    // Needed to automatically enable AWS SSO login
-    implementation("software.amazon.awssdk:sso")
+    implementation("software.amazon.awssdk:sso") {
+        because("Needed to automatically enable AWS SSO login, see https://stackoverflow.com/a/67824174")
+    }
     implementation("software.amazon.awssdk:s3") {
         // We do not use netty client so far
         exclude("software.amazon.awssdk", "netty-nio-client")


### PR DESCRIPTION
We are using [AWS SSO login](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) feature to authenticate our S3 instance.

This plugin just doesn't work with SSO by setting `lookupDefaultAwsCredentials = true`, forcing clients to configure the plugin with `awsAccessKeyId`, `awsSecretKey` and `sessionToken`.

We found out that just by adding the AWS SSO dependency will make the plugin work with no extra effort.

This [StackOverflow answer](https://stackoverflow.com/a/67824174) helped us.

As a workaround we have now added the same dependencies (BOM and SSO) to our `settings.gradle` as `buildscript.dependencies.classpath`, but it would be nice if it was supported by this plugin out of the box.

I took the opportunity to update AWS but feel free to revert that change.