### PR TITLE
Add AWS STS dependency.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
         // We do not use netty client so far
         exclude("software.amazon.awssdk", "netty-nio-client")
     }
+    runtimeOnly("software.amazon.awssdk:sts")
 
     testImplementation(platform("org.junit:junit-bom:5.7.1"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")


### PR DESCRIPTION
https://github.com/burrunan/gradle-s3-build-cache/issues/19

Without this dependency, the S3 client can not use profile-based authentication.

