### PR TITLE
Add support for AWS profile in remote cache DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### Unreleased
+ - *TBD*
+#### Changed
+ - Added support for specifying AWS profile in DSL
+
 #### 1.5
  - 2022-10-05 - [4 commits](https://github.com/burrunan/gradle-s3-build-cache/compare/v1.4...v1.5)
 #### Changed

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The AWS S3 build cache implementation has a few configuration options:
 | `awsAccessKeyId` | The AWS access key id | no | `getenv("S3_BUILD_CACHE_ACCESS_KEY_ID")` |
 | `awsSecretKey` | The AWS secret key | no | `getenv("S3_BUILD_CACHE_SECRET_KEY")` |
 | `sessionToken` | The AWS sessionToken when you use temporal credentials | no | `getenv("S3_BUILD_CACHE_SESSION_TOKEN")` |
+| `awsProfile` | The AWS profile to use for authentication | no | `getenv("S3_BUILD_CACHE_PROFILE")` |
 | `lookupDefaultAwsCredentials` | Configures if `DefaultAWSCredentialsProviderChain` could be used to lookup credentials | yes | false | 
 | `showStatistics` | Displays statistics on the remote cache performance | Yes | `true` |
 | `showStatisticsWhenImpactExceeds` | Specifies minimum duration to trigger printing the stats, milliseconds | Yes | `100` |
@@ -135,7 +136,11 @@ environment variables.
 
 If you want to use AWS default credentials [`DefaultAWSCredentialsProviderChain`](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html),
 then configure `lookupDefaultAwsCredentials=true`.
-Note: it will still try `S3_BUILD_CACHE_` variables first.
+
+If you want to use a specific [AWS profile](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-profiles.html),
+then configure `awsProfile="<profile_name>"`.
+
+Note: even with these values set, it will still try `S3_BUILD_CACHE_` variables first.
 
 ### S3 Bucket Permissions for cache population
 

--- a/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
@@ -28,6 +28,7 @@ open class AwsS3BuildCache : AbstractBuildCache() {
     var awsAccessKeyId: String? = System.getenv("S3_BUILD_CACHE_ACCESS_KEY_ID")
     var awsSecretKey: String? = System.getenv("S3_BUILD_CACHE_SECRET_KEY")
     var sessionToken: String? = System.getenv("S3_BUILD_CACHE_SESSION_TOKEN")
+    var awsProfile: String? = System.getenv("S3_BUILD_CACHE_PROFILE")
     var lookupDefaultAwsCredentials: Boolean = false
     var showStatistics: Boolean = true
     var showStatisticsWhenImpactExceeds: Long = 100

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
@@ -99,6 +100,8 @@ class AwsS3BuildCacheServiceFactory : BuildCacheServiceFactory<AwsS3BuildCache> 
         val credentials = when {
             config.awsAccessKeyId.isNullOrBlank() || config.awsSecretKey.isNullOrBlank() -> when {
                 config.lookupDefaultAwsCredentials -> return
+                !config.awsProfile.isNullOrBlank() ->
+                    ProfileCredentialsProvider.create(config.awsProfile)
                 else -> AnonymousCredentialsProvider.create()
             }
             else ->

--- a/src/test/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactoryTest.kt
+++ b/src/test/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactoryTest.kt
@@ -125,4 +125,15 @@ class AwsS3BuildCacheServiceFactoryTest {
         val service = subject.createBuildCacheService(conf, buildCacheDescriber)
         Assertions.assertNotNull(service)
     }
+
+    @Test
+    fun testAWSProfileCredentials() {
+        val conf = buildCache {
+            bucket = "my-bucket"
+            region = "us-west-1"
+            awsProfile = "any aws profile"
+        }
+        val service = subject.createBuildCacheService(conf, buildCacheDescriber)
+        Assertions.assertNotNull(service)
+    }
 }


### PR DESCRIPTION
This change is relatively simple, more info in the commit message. But I haven't been able to build locally. Something about not having Kotlin set up properly for this. That being said, I'd appreciate if you'd take a look at it and verify. It's minor, but it would be a huge quality of life improvement for us.