### PR TITLE
Allow passing instance of AwsCredentialsProvider to configuration

### DIFF
--- a/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
@@ -16,6 +16,7 @@
 package com.github.burrunan.s3cache
 
 import org.gradle.caching.configuration.AbstractBuildCache
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
 open class AwsS3BuildCache : AbstractBuildCache() {
     var region: String? = null
@@ -31,6 +32,7 @@ open class AwsS3BuildCache : AbstractBuildCache() {
     var sessionToken: String? = System.getenv("S3_BUILD_CACHE_SESSION_TOKEN")
     var awsProfile: String? = System.getenv("S3_BUILD_CACHE_PROFILE")
     var lookupDefaultAwsCredentials: Boolean = false
+    var credentialsProvider: AwsCredentialsProvider? = null
     var showStatistics: Boolean = true
     var showStatisticsWhenImpactExceeds: Long = 100
     var showStatisticsWhenSavingsExceeds: Long = 100

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
@@ -104,6 +104,7 @@ class AwsS3BuildCacheServiceFactory : BuildCacheServiceFactory<AwsS3BuildCache> 
 
     private fun S3ClientBuilder.addCredentials(config: AwsS3BuildCache) {
         val credentials = when {
+            config.credentialsProvider != null -> config.credentialsProvider
             config.awsAccessKeyId.isNullOrBlank() || config.awsSecretKey.isNullOrBlank() -> when {
                 config.lookupDefaultAwsCredentials -> return
                 !config.awsProfile.isNullOrBlank() ->

--- a/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
+++ b/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
@@ -119,6 +119,7 @@ class RemoteCacheTest : BaseGradleTest() {
 
         createSettings(
             """
+            import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
             buildCache {
                 local {
                     // Only remote cache should be used
@@ -132,6 +133,7 @@ class RemoteCacheTest : BaseGradleTest() {
                     // See https://github.com/adobe/S3Mock/issues/880
                     forcePathStyle = true
                     push = true
+                    credentialsProvider = AnonymousCredentialsProvider.create()
                 }
             }
         """.trimIndent()

--- a/src/test/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactoryTest.kt
+++ b/src/test/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactoryTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
 
 class AwsS3BuildCacheServiceFactoryTest {
     private lateinit var subject: AwsS3BuildCacheServiceFactory
@@ -132,6 +133,17 @@ class AwsS3BuildCacheServiceFactoryTest {
             bucket = "my-bucket"
             region = "us-west-1"
             awsProfile = "any aws profile"
+        }
+        val service = subject.createBuildCacheService(conf, buildCacheDescriber)
+        Assertions.assertNotNull(service)
+    }
+
+    @Test
+    fun testAWSProviderCredentials() {
+        val conf = buildCache {
+            bucket = "my-bucket"
+            region = "us-west-1"
+            credentialsProvider = AnonymousCredentialsProvider.create()
         }
         val service = subject.createBuildCacheService(conf, buildCacheDescriber)
         Assertions.assertNotNull(service)


### PR DESCRIPTION
This enables being more explicit about the provider chain to use in cases where the `lookupDefaultAwsCredentials` is not viable, or where you have a custom subclass of `AwsCredentialsProvider` you need to use.