### PR TITLE
To support reusing configuration cache when short time lived aws credential are update

### DIFF
--- a/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
@@ -15,6 +15,7 @@
  */
 package com.github.burrunan.s3cache
 
+import org.gradle.api.provider.Provider
 import org.gradle.caching.configuration.AbstractBuildCache
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
@@ -28,10 +29,10 @@ open class AwsS3BuildCache : AbstractBuildCache() {
     var endpoint: String? = null
     var forcePathStyle: Boolean = false
     var headers: Map<String?, String?>? = null
-    var awsAccessKeyId: String? = System.getenv("S3_BUILD_CACHE_ACCESS_KEY_ID")
-    var awsSecretKey: String? = System.getenv("S3_BUILD_CACHE_SECRET_KEY")
-    var sessionToken: String? = System.getenv("S3_BUILD_CACHE_SESSION_TOKEN")
-    var awsProfile: String? = System.getenv("S3_BUILD_CACHE_PROFILE")
+    var awsAccessKeyId: Provider<String?>? = null
+    var awsSecretKey: Provider<String?>? = null
+    var sessionToken: Provider<String?>? = null
+    var awsProfile: Provider<String?>? = null
     var lookupDefaultAwsCredentials: Boolean = false
     var credentialsProvider: AwsCredentialsProvider? = null
     var showStatistics: Boolean = true

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
@@ -117,12 +117,12 @@ class AwsS3BuildCacheServiceFactory : BuildCacheServiceFactory<AwsS3BuildCache> 
     }
 
     private fun S3ClientBuilder.addCredentials(config: AwsS3BuildCache) {
-        val awsAccessKeyId = config.awsAccessKeyId?.getOrElse("")  ?: ""
-        val awsSecretKey = config.awsSecretKey?.getOrElse("") ?: ""
+        val awsAccessKeyId = config.awsAccessKeyId?.orNull  ?: ""
+        val awsSecretKey = config.awsSecretKey?.orNull ?: ""
         val credentials = when {
             config.credentialsProvider != null -> config.credentialsProvider
             awsAccessKeyId.isBlank() || awsSecretKey.isBlank() -> {
-                val awsProfile = config.awsProfile?.getOrElse("")
+                val awsProfile = config.awsProfile?.orNull
                 when {
                     config.lookupDefaultAwsCredentials -> return
                     !awsProfile.isNullOrBlank() ->
@@ -133,7 +133,7 @@ class AwsS3BuildCacheServiceFactory : BuildCacheServiceFactory<AwsS3BuildCache> 
             }
 
             else -> {
-                val sessionToken = config.sessionToken?.getOrElse("") ?: ""
+                val sessionToken = config.sessionToken?.orNull ?: ""
                 StaticCredentialsProvider.create(
                     if (sessionToken.isNotEmpty() == true) {
                         AwsBasicCredentials.create(awsAccessKeyId, awsSecretKey)

--- a/src/test/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactoryTest.kt
+++ b/src/test/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactoryTest.kt
@@ -16,6 +16,7 @@
 package com.github.burrunan.s3cache.internal
 
 import com.github.burrunan.s3cache.AwsS3BuildCache
+import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.caching.BuildCacheServiceFactory
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -119,9 +120,9 @@ class AwsS3BuildCacheServiceFactoryTest {
         val conf = buildCache {
             bucket = "my-bucket"
             region = "us-west-1"
-            awsAccessKeyId = "any aws access key"
-            awsSecretKey = "any secret key"
-            sessionToken = "any session token"
+            awsAccessKeyId = DefaultProvider { "any aws access key" }
+            awsSecretKey = DefaultProvider { "any secret key" }
+            sessionToken = DefaultProvider { "any session token" }
         }
         val service = subject.createBuildCacheService(conf, buildCacheDescriber)
         Assertions.assertNotNull(service)
@@ -132,7 +133,7 @@ class AwsS3BuildCacheServiceFactoryTest {
         val conf = buildCache {
             bucket = "my-bucket"
             region = "us-west-1"
-            awsProfile = "any aws profile"
+            awsProfile = DefaultProvider { "any aws profile" }
         }
         val service = subject.createBuildCacheService(conf, buildCacheDescriber)
         Assertions.assertNotNull(service)


### PR DESCRIPTION
I would like to support the configuration cache being reusable when only AWS environment variables. In our project we are using AWS short lived credential and the session key is updated every time when we triggered the workflow. Because the current code read the value from `System.getenv(XXXX)` instead of gradle provider value so the configuration cache cannot be reused.

I update the way to allow us to read the value from outside and also provide testcase to verify the behavior to make sure the configuration cache can be reused when the aws environment value is updated.

I am not quite expert in the gradle api so appreciate any suggestion on it 😄 