### PR TITLE
feat: add customization for s3client and s3configuration

### DIFF
--- a/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/AwsS3BuildCache.kt
@@ -15,8 +15,11 @@
  */
 package com.github.burrunan.s3cache
 
+import org.gradle.api.Action
 import org.gradle.caching.configuration.AbstractBuildCache
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.services.s3.S3ClientBuilder
+import software.amazon.awssdk.services.s3.S3Configuration
 
 open class AwsS3BuildCache : AbstractBuildCache() {
     var region: String? = null
@@ -51,4 +54,14 @@ open class AwsS3BuildCache : AbstractBuildCache() {
     var showStatisticsWhenWasteExceeds: Long = 100
     var showStatisticsWhenTransferExceeds: Long = 10 * 1024 * 1024
     var transferAcceleration: Boolean? = false
+    internal val s3ClientActions = mutableListOf<Action<S3ClientBuilder>>()
+    internal val s3ConfigurationActions = mutableListOf<Action<S3Configuration.Builder>>()
+
+    fun s3client(action: Action<S3ClientBuilder>) {
+        s3ClientActions += action
+    }
+
+    fun s3configuration(action: Action<S3Configuration.Builder>) {
+        s3ConfigurationActions += action
+    }
 }

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheServiceFactory.kt
@@ -89,6 +89,7 @@ class AwsS3BuildCacheServiceFactory : BuildCacheServiceFactory<AwsS3BuildCache> 
             endpointOverride(URI.create(endpoint))
         }
         transferAcceleration(config)
+        config.s3ClientActions.forEach { it.execute(this) }
         build()
     }
 
@@ -142,7 +143,10 @@ class AwsS3BuildCacheServiceFactory : BuildCacheServiceFactory<AwsS3BuildCache> 
     }
 
     private fun S3ClientBuilder.transferAcceleration(config: AwsS3BuildCache) {
-        val s3Conf = S3Configuration.builder().accelerateModeEnabled(config.transferAcceleration).build()
+        val s3Conf = S3Configuration.builder().apply {
+            accelerateModeEnabled(config.transferAcceleration)
+            config.s3ConfigurationActions.forEach { it.execute(this) }
+        }.build()
         serviceConfiguration(s3Conf)
     }
 }

--- a/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
+++ b/src/test/kotlin/com/github/burrunan/s3cache/RemoteCacheTest.kt
@@ -140,6 +140,9 @@ class RemoteCacheTest : BaseGradleTest() {
                     forcePathStyle = true
                     push = true
                     credentialsProvider = AnonymousCredentialsProvider.create()
+                    s3configuration {
+                      accelerateModeEnabled(false)
+                    }
                 }
             }
         """.trimIndent()


### PR DESCRIPTION
It enables fine-tune the client.
Note: the exposed builders are from AWS SDK, and you probably want to call setter methods rather that getters.

For instance, the following would do nothing:

```kotlin
s3configuration {
  // Retrieves the current  mode
  // It does not change the configuration
  accelerateModeEnabled()
}
```

while the following is the right way to set the mode:

```kotlin
s3configuration {
  // Enables the acceleration
  accelerateModeEnabled(true)
}
```

Fixes https://github.com/burrunan/gradle-s3-build-cache/issues/91