### PR TITLE
chore: add gradle-dependency-submission workflow

### DIFF
--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -1,0 +1,28 @@
+name: Dependency Submission
+
+# See https://github.com/gradle/actions/blob/768a17f3488dc3fe0155ff431553e1f53d57e22e/dependency-submission/README.md#the-dependency-submission-action
+# The action allows GitHub to alert about reported vulnerabilities in the project
+on:
+  push:
+    branches:
+      - master
+
+# Declare default permissions as read-only.
+permissions: read-all
+
+jobs:
+  dependency-submission:
+    name: Submit dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+      with:
+        distribution: zulu
+        java-version: 21
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4


### PR DESCRIPTION
This enables detecting CVEs in transitive dependencies