### PR TITLE
chore: bump minimal test Java version to 17 (keep targeting Java 8 bytecode for the main artifac)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: |
-          8
+          17
           21
         distribution: 'zulu'
     - uses: actions/cache@v4
@@ -32,11 +32,11 @@ jobs:
         path: |
           ~/.gradle/caches/
         key: gradle-${{ runner.os }}-caches-${{ hashFiles('build.properties', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
-    - name: Test with Java 8
+    - name: Test with Java 17
       uses: eskatos/gradle-command-action@v3
       with:
         gradle-version: wrapper
-        arguments: --no-parallel --no-daemon build
+        arguments: --no-parallel --no-daemon PtestJdk=17 build
     - name: Test with Java 21
       uses: eskatos/gradle-command-action@v3
       with:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Key improvements are (as of 2020-07-24):
 
 * Version 1.0.0 - Gradle 4.1+
 * Gradle configuration cache - Gradle 7.5+, see https://github.com/gradle/gradle/issues/14874
+* Java 8+: the build targets Java 8 bytecode and class libraries. It is recommended to use Java 17+ for launching Gradle though.
 
 ## Use in your project
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.13.4"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("com.adobe.testing:s3mock-junit5:2.17.0") {
+    testImplementation("com.adobe.testing:s3mock-junit5:4.7.0") {
         // Gradle has its own logging
         exclude("ch.qos.logback", "logback-classic")
         exclude("org.apache.logging.log4j", "log4j-to-slf4j")
@@ -193,6 +193,10 @@ allprojects {
             configureEach<JavaCompile> {
                 options.encoding = "UTF-8"
                 options.release.set(targetJdk)
+            }
+
+            compileTestJava {
+                options.release.set(testJdk)
             }
 
             afterEvaluate {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ description=Gradle S3 Build Cache
 centralPortalPublishingTimeout=180
 buildJdk=21
 targetJdk=8
-testJdk=8
+testJdk=17

--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,6 @@
   "schedule": ["every 3 weeks on Monday"],
   "packageRules": [
     {
-      "matchPackageNames": ["com.adobe.testing:s3mock-junit5"],
-      "groupName": "s3mock-junit5",
-      "allowedVersions": "< 3.0"
-    },
-    {
       "matchPackagePrefixes": ["com.github.vlsi"],
       "groupName": "com.github.vlsi"
     }


### PR DESCRIPTION
Test libraries require Java 17 (e.g. com.adobe.testing:s3mock-junit5), so we bump the minimal Java when executing the tests.

It should not affect the resulting bytecode for the main artifact, however, it does inded make the plugin less tested with Java 8 runtime.