### PR TITLE
chore(renovate): enable automerge for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "labels": ["dependencies"],
   "schedule": ["every 3 weeks on Monday"],
+  "automerge": true,
   "packageRules": [
     {
       "matchPackagePrefixes": ["com.github.vlsi"],


### PR DESCRIPTION
## Why

Dependency-update PRs from Renovate are merged by hand today. The project already runs a full test matrix on every PR (`main.yml`), so green updates can merge on their own.

## What

- Set `automerge: true` in `renovate.json`, applying to every update including major.
- Migrate the deprecated `config:base` preset to `config:recommended`.
- Enable repository settings via the GitHub API (outside the diff):
  - `allow_auto_merge` — lets Renovate use GitHub native auto-merge (`platformAutomerge`, on by default).
  - `delete_branch_on_merge` — removes merged Renovate branches.

## How to verify

- Renovate validates the config on its next run; the `config:base` deprecation warning disappears.
- The next Renovate PR is queued for auto-merge and merges once CI passes.
- `gh api repos/burrunan/gradle-s3-build-cache --jq '{allow_auto_merge, delete_branch_on_merge}'` reports both `true`.