### PR TITLE
ci(release): run release monthly via schedule trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
         type: string
         default: ''
         description: Release version number (without v, defaults to gradle.properties)
+  schedule:
+    # Release on the 1st of every month at 09:07 UTC.
+    # Scheduled runs use the version from gradle.properties (no input is passed).
+    - cron: '7 9 1 * *'
 
 jobs:
   publish-release:


### PR DESCRIPTION
## Why

The release workflow could only be started manually via `workflow_dispatch`. We want releases to go out automatically once a month without a maintainer remembering to trigger them.

## What

Add a `schedule` trigger to `.github/workflows/release.yaml` so the existing release job also runs on the 1st of every month at 09:07 UTC. The manual `workflow_dispatch` entry point is unchanged.

## How it works with the existing job

- **Version.** Scheduled runs pass no `version` input, so `inputs.version` is empty and the job falls back to `current.version` from `gradle.properties` — the intended behaviour.
- **Branch.** `schedule` events run on the default branch (`master`), so the in-job `^(master|release/.+)$` branch check passes.
- **Tag.** After each release the version is already bumped to the next patch, so the `v<version>` tag does not yet exist and the "tag exists" guard passes.

## Notes for reviewers

- Cron is UTC and does not follow daylight-saving changes. The minute is deliberately non-zero (`7 9 1 * *`): runners are busiest at the top of the hour, so a `:00` schedule is more likely to be delayed or skipped.
- GitHub disables scheduled workflows after 60 days of repository inactivity. Renovate's regular dependency merges keep this repo active, so it should not trigger here.
- Per the chosen behaviour, a release is published every month even when nothing changed since the last one; the version is bumped each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)