### PR TITLE
ci: pin remaining actions to commit SHA

### DIFF
--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -25,4 +25,4 @@ jobs:
         distribution: zulu
         java-version: 21
     - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      uses: gradle/actions/dependency-submission@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: gradle/actions/wrapper-validation@v5
+      - uses: gradle/actions/wrapper-validation@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,12 @@ jobs:
           ~/.gradle/caches/
         key: gradle-${{ runner.os }}-caches-${{ hashFiles('build.properties', '**/*.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
     - name: Test with Java 17
-      uses: eskatos/gradle-command-action@v3
+      uses: eskatos/gradle-command-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: wrapper
         arguments: --no-parallel --no-daemon -PtestJdk=17 build
     - name: Test with Java 21
-      uses: eskatos/gradle-command-action@v3
+      uses: eskatos/gradle-command-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
       with:
         gradle-version: wrapper
         arguments: --no-parallel --no-daemon -PtestJdk=21 build


### PR DESCRIPTION
## Why

A few workflow steps still referenced moving major tags instead of a commit SHA, so an upstream re-tag would silently change what runs in CI. The rest of the repo already pins actions as `action@sha # <tag>`; these were the stragglers.

## What

- `eskatos/gradle-command-action`: `@v3` → `@ac2d340 # v3.5.0` (the commit `v3` currently resolves to)
- `gradle/actions/wrapper-validation`: `@v5` → `@4d9f0ba # v5.0.0`, reusing the SHA already pinned for `dependency-submission` so both `gradle/actions` references stay in lockstep
- `gradle/actions/dependency-submission`: clarify the comment from `# v5` to the exact `# v5.0.0` the pinned SHA resolves to

No behaviour change — each SHA is what the previous tag pointed at.

## How to verify

```
git ls-remote --tags https://github.com/eskatos/gradle-command-action | grep 'v3\^{}'
git ls-remote --tags https://github.com/gradle/actions | grep 'v5.0.0\^{}'
```

confirms `ac2d340…` = `v3.5.0` and `4d9f0ba…` = `v5.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)