### PR TITLE
chore: bump version to 1.9.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel=true
 kotlin.parallel.tasks.in.project=true
 
-current.version=1.9.6
+current.version=1.9.7
 artifact.name=gradle-s3-build-cache
 description=Gradle S3 Build Cache
 


### PR DESCRIPTION
The scheduled release of `1.9.6` published successfully, but the final `update_version` step that bumps `gradle.properties` to the next patch failed on CI, so `current.version` was left at `1.9.6`. This applies that bump manually.

- `current.version`: `1.9.6` → `1.9.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)