### PR TITLE
ci: enable Renovate automerge for minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
     {
       "matchPackagePrefixes": ["com.github.vlsi"],
       "groupName": "com.github.vlsi"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
     }
-  ]
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
Why: dependency PRs from Renovate sit waiting for a manual merge click even when CI is green. This repo already has the pieces to close that gap safely: a branch ruleset on the default branch that requires the `Test` status check (the Java 17/21 Gradle build), and `allow_auto_merge` is enabled.

What: enable automerge in `renovate.json`, scoped to `minor`, `patch`, `pin`, and `digest` updates. Major bumps still require review. `platformAutomerge` uses GitHub's native auto-merge, so the required `Test` check is what actually holds the merge — Renovate does not merge on its own if the build fails.

How to verify:
- On the next minor/patch Renovate PR, confirm auto-merge is set and the PR merges once `Test` passes.
- Make `Test` fail once on such a PR and confirm it does not merge.