### PR TITLE
Use `BuildCacheEntryWriter.getInputStream` on Gradle 9.7+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,11 +15,11 @@ plugins {
     `maven-publish`
     kotlin("jvm")
     `kotlin-dsl`
-    id("com.gradle.plugin-publish") version "2.1.1"
-    id("com.github.vlsi.crlf") version "3.0.2"
-    id("com.github.vlsi.gradle-extensions") version "3.0.2"
-    id("com.gradleup.nmcp") version "1.6.1"
-    id("com.gradleup.nmcp.aggregation") version "1.6.1"
+    id("com.gradle.plugin-publish") version "2.0.0"
+    id("com.github.vlsi.crlf") version "3.0.1"
+    id("com.github.vlsi.gradle-extensions") version "3.0.1"
+    id("com.gradleup.nmcp") version "1.5.0"
+    id("com.gradleup.nmcp.aggregation") version "1.5.0"
     id("signing")
 }
 
@@ -54,7 +54,7 @@ dependencies {
     }
     nmcpAggregation(project(":"))
 
-    implementation(platform("software.amazon.awssdk:bom:2.49.3"))
+    implementation(platform("software.amazon.awssdk:bom:2.46.6"))
     implementation("software.amazon.awssdk:sso") {
         because("Needed to automatically enable AWS SSO login, see https://stackoverflow.com/a/67824174")
     }
@@ -67,10 +67,10 @@ dependencies {
     }
     runtimeOnly("software.amazon.awssdk:sts")
 
-    testImplementation(platform("org.junit:junit-bom:6.1.2"))
+    testImplementation(platform("org.junit:junit-bom:6.1.0"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("com.adobe.testing:s3mock-junit5:4.12.4") {
+    testImplementation("com.adobe.testing:s3mock-junit5:4.11.0") {
         // Gradle has its own logging
         exclude("ch.qos.logback", "logback-classic")
         exclude("org.apache.logging.log4j", "log4j-to-slf4j")
@@ -95,7 +95,7 @@ gradlePlugin {
 }
 
 tasks.wrapper {
-    gradleVersion = "9.6.1"
+    gradleVersion = "9.7.0"
     distributionType = DistributionType.BIN
 }
 
@@ -257,8 +257,8 @@ allprojects {
 
         tasks.configureEach<KotlinJvmCompile> {
             compilerOptions {
-                @Suppress("DEPRECATION")
-                val kotlinVersion = KotlinVersion.KOTLIN_1_9
+                // Gradle 9.7 embeds a Kotlin compiler that no longer supports language version 1.9
+                val kotlinVersion = KotlinVersion.KOTLIN_2_0
                 apiVersion = kotlinVersion
                 languageVersion = kotlinVersion
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheService.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/AwsS3BuildCacheService.kt
@@ -25,12 +25,10 @@ import org.gradle.caching.BuildCacheService
 import org.gradle.util.GradleVersion
 import software.amazon.awssdk.core.exception.SdkException
 import software.amazon.awssdk.core.exception.SdkServiceException
-import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.StorageClass
-import java.io.ByteArrayOutputStream
 import java.util.*
 import kotlin.math.absoluteValue
 
@@ -49,10 +47,6 @@ class AwsS3BuildCacheService internal constructor(
     private val showStatisticsWhenWasteExceeds: Long,
     private val showStatisticsWhenTransferExceeds: Long
 ) : BuildCacheService {
-    companion object {
-        private const val BUILD_CACHE_CONTENT_TYPE = "application/vnd.gradle.build-cache-artifact"
-    }
-
     // S3 client is created lazily, so it is created at execution time rather than configuration time
     private val s3 by lazy(s3Factory)
 
@@ -231,7 +225,7 @@ class AwsS3BuildCacheService internal constructor(
         }
         bytesProcessed(itemSize)
         logger.info("Storing cache entry '{}' to S3 bucket", bucketPath)
-        val metadata = writer.readBuildMetadata() ?: CURRENT_TASK.get()?.let {
+        val metadata = cacheEntryContentAdapter.readBuildMetadata(writer) ?: CURRENT_TASK.get()?.let {
             CacheEntryMetadata(
                 buildInvocationId = buildId,
                 identity = it.path,
@@ -259,11 +253,7 @@ class AwsS3BuildCacheService internal constructor(
                         it.storageClass(StorageClass.REDUCED_REDUNDANCY)
                     }
                 },
-                writer.file()?.let { RequestBody.fromFile(it) } ?: RequestBody.fromBytes(
-                    ByteArrayOutputStream()
-                        .also { os -> writer.writeTo(os) }
-                        .toByteArray()
-                )
+                cacheEntryContentAdapter.createRequestBody(writer)
             )
         } catch (e: SdkException) {
             throw BuildCacheException(

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/CacheEntryContentAdapter.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/CacheEntryContentAdapter.kt
@@ -1,0 +1,70 @@
+package com.github.burrunan.s3cache.internal
+
+import org.gradle.caching.BuildCacheEntryWriter
+import org.gradle.util.GradleVersion
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.http.ContentStreamProvider
+import java.io.ByteArrayOutputStream
+
+internal const val BUILD_CACHE_CONTENT_TYPE = "application/vnd.gradle.build-cache-artifact"
+
+/**
+ * Abstracts how the cache entry contents are obtained from a [BuildCacheEntryWriter].
+ */
+internal interface CacheEntryContentAdapter {
+    fun createRequestBody(writer: BuildCacheEntryWriter): RequestBody
+    fun readBuildMetadata(writer: BuildCacheEntryWriter): CacheEntryMetadata?
+}
+
+/**
+ * The adapter matching the running Gradle version, selected once,
+ * so cache operations perform no version checks.
+ */
+internal val cacheEntryContentAdapter: CacheEntryContentAdapter =
+    if (GradleVersion.current().baseVersion >= GradleVersion.version("9.7")) {
+        StreamingCacheEntryContentAdapter
+    } else {
+        LegacyCacheEntryContentAdapter
+    }
+
+/**
+ * Streams cache entry contents via `BuildCacheEntryWriter.getInputStream()`, which returns
+ * a fresh stream on every call, so the AWS SDK can re-read the contents on upload retries.
+ * Must only be used on Gradle 9.7+, older versions fail with [NoSuchMethodError].
+ */
+internal object StreamingCacheEntryContentAdapter : CacheEntryContentAdapter {
+    override fun createRequestBody(writer: BuildCacheEntryWriter): RequestBody =
+        RequestBody.fromContentProvider(
+            // the provider closes each superseded stream, the SDK closes the last one
+            ContentStreamProvider.fromInputStreamSupplier { writer.inputStream },
+            writer.size,
+            BUILD_CACHE_CONTENT_TYPE
+        )
+
+    override fun readBuildMetadata(writer: BuildCacheEntryWriter): CacheEntryMetadata? = try {
+        writer.inputStream.use { it.readBuildMetadata() }
+    } catch (ignore: Throwable) {
+        null
+    }
+}
+
+/**
+ * Before Gradle 9.7 the only supported way to get the contents was `writeTo(OutputStream)`,
+ * so this adapter reflectively reads the writer's backing file when possible,
+ * and buffers the contents in memory otherwise.
+ */
+internal object LegacyCacheEntryContentAdapter : CacheEntryContentAdapter {
+    override fun createRequestBody(writer: BuildCacheEntryWriter): RequestBody =
+        writer.file()?.let { RequestBody.fromFile(it) }
+            ?: RequestBody.fromBytes(
+                ByteArrayOutputStream()
+                    .also { os -> writer.writeTo(os) }
+                    .toByteArray()
+            )
+
+    override fun readBuildMetadata(writer: BuildCacheEntryWriter): CacheEntryMetadata? = try {
+        writer.file()?.readBuildMetadata()
+    } catch (ignore: Throwable) {
+        null
+    }
+}

--- a/src/main/kotlin/com/github/burrunan/s3cache/internal/MetadataReader.kt
+++ b/src/main/kotlin/com/github/burrunan/s3cache/internal/MetadataReader.kt
@@ -17,8 +17,8 @@
 package com.github.burrunan.s3cache.internal
 
 import com.github.burrunan.s3cache.internal.tar.TarInputStream
-import org.gradle.caching.BuildCacheEntryWriter
 import java.io.File
+import java.io.InputStream
 import java.nio.charset.StandardCharsets
 import java.util.*
 import java.util.zip.GZIPInputStream
@@ -47,34 +47,32 @@ fun CacheEntryMetadata(map: Map<String, String>) = CacheEntryMetadata(
     gradleVersion = map["gradleVersion"]
 )
 
-fun BuildCacheEntryWriter.readBuildMetadata(): CacheEntryMetadata? = try {
-    file()?.readBuildMetadata()
+internal fun File.readBuildMetadata(): CacheEntryMetadata? = try {
+    inputStream().use { it.readBuildMetadata() }
 } catch (ignore: Throwable) {
     null
 }
 
-fun File.readBuildMetadata(): CacheEntryMetadata? {
+internal fun InputStream.readBuildMetadata(): CacheEntryMetadata? {
     try {
-        inputStream().use { fileStream ->
-            GZIPInputStream(fileStream).use { ungzip ->
-                TarInputStream(ungzip, StandardCharsets.UTF_8.name()).use { tar ->
-                    val entry = tar.nextEntry ?: return null
-                    if (!entry.isFile || entry.name != "METADATA" || entry.size > 10000) {
-                        return null
-                    }
-                    val buffer = ByteArray(entry.size.toInt())
-                    if (tar.read(buffer) != buffer.size) {
-                        return null
-                    }
-                    val parsed = Properties().apply { load(buffer.inputStream()) }
-                    return CacheEntryMetadata(
-                        buildInvocationId = parsed.getProperty("buildInvocationId"),
-                        identity = parsed.getProperty("identity"),
-                        executionTime = parsed.getProperty("executionTime")?.toLong(),
-                        operatingSystem = parsed.getProperty("operatingSystem"),
-                        gradleVersion = parsed.getProperty("gradleVersion")
-                    )
+        GZIPInputStream(this).use { ungzip ->
+            TarInputStream(ungzip, StandardCharsets.UTF_8.name()).use { tar ->
+                val entry = tar.nextEntry ?: return null
+                if (!entry.isFile || entry.name != "METADATA" || entry.size > 10000) {
+                    return null
                 }
+                val buffer = ByteArray(entry.size.toInt())
+                if (tar.read(buffer) != buffer.size) {
+                    return null
+                }
+                val parsed = Properties().apply { load(buffer.inputStream()) }
+                return CacheEntryMetadata(
+                    buildInvocationId = parsed.getProperty("buildInvocationId"),
+                    identity = parsed.getProperty("identity"),
+                    executionTime = parsed.getProperty("executionTime")?.toLong(),
+                    operatingSystem = parsed.getProperty("operatingSystem"),
+                    gradleVersion = parsed.getProperty("gradleVersion")
+                )
             }
         }
     } catch (ignore: Throwable) {


### PR DESCRIPTION
The cache entry content adapter is selected once based on the Gradle version. On 9.7+ uploads stream through the new API instead of reflecting on the writer's private file field, and the whole-entry in-memory fallback is no longer reachable. Older Gradle versions keep the previous behavior.

Building now requires Gradle 9.7, which also forces Kotlin language version 2.0 since its embedded compiler dropped 1.9.